### PR TITLE
Add batch MCP tool with pagination for large responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Available functionality:
 
 - `list_instances()`: List all IDA Pro databases currently registered by the MCP plugin along with their status, load time, PID, and runtime socket path.
 - `check_connection(database)`: Check if the IDA plugin instance handling `database` is running.
+- `batch_tool_calls(requests, page=1, page_size_tokens=25000, allow_unsafe=False)`: Execute multiple MCP tool calls in one request and automatically paginate the combined results when they exceed ~25k tokens.
 - **Important**: Every other tool accepts the target `database` filename as its first argument so the correct IDA instance is used.
 - `get_metadata(database)`: Get metadata about the current IDB.
 - `get_function_by_name(database, name)`: Get a function by its name.


### PR DESCRIPTION
## Summary
- add a `batch_tool_calls` MCP tool that executes multiple tool invocations sequentially, supports optional unsafe execution, and paginates large responses
- introduce helpers to normalize results, split oversized outputs into manageable chunks, and expose the new tool through the generated function lists and README

## Testing
- uv run python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d1c0d5e98c832f857220ecadcad701